### PR TITLE
Dev 011

### DIFF
--- a/Assets/Scripts/CorpseController.cs
+++ b/Assets/Scripts/CorpseController.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CorpseController : MonoBehaviour
+{
+    public Transform ground; //temporal assignment
+
+    private void Update() {
+        if(this.transform.position.y <= ground.transform.position.y){
+            if(this.gameObject.TryGetComponent<Rigidbody2D>(out var rb)){
+                //Reset
+                rb.mass = 1;
+                rb.angularVelocity = 0;
+                rb.velocity = Vector2.zero;
+
+                //Torque effect
+                rb.AddTorque( Random.Range(290,780) );
+                
+                //this would only offset the speed from the player vehicle
+                //For now, it just generates a random number
+                var gameVel = Random.Range(-500, -950); 
+                var bounce = Random.Range(20, 210);
+                rb.AddForce(new Vector2(gameVel, bounce));
+            }
+        }
+    }
+}

--- a/Assets/Scripts/CorpseController.cs.meta
+++ b/Assets/Scripts/CorpseController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 203f1eaa8f4eb2043b61b09b268fae6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Descripción de la Funcionalidad :black_nib:

Added Corpse controller with temporary behaviour.
Behaviour will be tightly tied with the player vehicle's speed,  enemy behaviour and health component logic, so most of the corpse component's behaviour is provisional and prototypical. 

![gTY2hBIa44](https://user-images.githubusercontent.com/22423324/85925754-e5513400-b89a-11ea-803a-33a737d9fa33.gif)

#### Historia de Usuario / Tarea :clipboard:

[Tarea en Trello](https://trello.com/c/lUa8PeFz/40-componente-de-cadaver)

#### ¿Cómo probar la funcionalidad? :video_game:

Pasos a recrear: 

1. Agregar un transform a cualquier escena y colocarla al nivel del 'suelo'.
2. Agregar Corpse component al objeto en cuestión.
3. Agregar referencia al suelo en corpse component.
