### PR TITLE
Dev 037

### DIFF
--- a/Assets/Scripts/Infrastructure/Helpers/GameHelper.cs
+++ b/Assets/Scripts/Infrastructure/Helpers/GameHelper.cs
@@ -6,19 +6,11 @@ public static class GameHelper
 {
     private static GameManagerScript gameManager;
     public static GameManagerScript GameManager { get => gameManager ?? GetGameManager(); set => gameManager = value; }
+    private static GameManagerScript GetGameManager(){ return gameManager = GameObject.Find("GameManager").GetComponent<GameManagerScript>(); }
     
     private static PlayerController player;
     public static PlayerController Player { get => player ?? GetPlayerController(); set => player = value; }
-
-    private static GameManagerScript GetGameManager(){
-        gameManager = GameObject.Find("GameManager").GetComponent<GameManagerScript>();
-        return gameManager;
-    } 
-
-    private static PlayerController GetPlayerController(){
-        player = GameObject.Find("Player").GetComponent<PlayerController>();
-        return player;
-    }
+    private static PlayerController GetPlayerController(){ return player = GameObject.Find("Player").GetComponent<PlayerController>(); }
 
     public static void ClearCache(){
         gameManager = null;

--- a/Assets/Scripts/Infrastructure/Helpers/GameHelper.cs
+++ b/Assets/Scripts/Infrastructure/Helpers/GameHelper.cs
@@ -4,7 +4,24 @@ using UnityEngine;
 
 public static class GameHelper
 {
-    public static GameManagerScript GameManager { get => GameObject.Find("GameManager").GetComponent<GameManagerScript>(); }
-    public static PlayerController Player {get => GameObject.Find("Player").GetComponent<PlayerController>(); }
+    private static GameManagerScript gameManager;
+    public static GameManagerScript GameManager { get => gameManager ?? GetGameManager(); set => gameManager = value; }
+    
+    private static PlayerController player;
+    public static PlayerController Player { get => player ?? GetPlayerController(); set => player = value; }
 
+    private static GameManagerScript GetGameManager(){
+        gameManager = GameObject.Find("GameManager").GetComponent<GameManagerScript>();
+        return gameManager;
+    } 
+
+    private static PlayerController GetPlayerController(){
+        player = GameObject.Find("Player").GetComponent<PlayerController>();
+        return player;
+    }
+
+    public static void ClearCache(){
+        gameManager = null;
+        player = null;
+    }
 }


### PR DESCRIPTION
## Descripción de la Funcionalidad :black_nib:

En demanda, GameHelper utilizaba GameObject.Find para encontrar el objeto en cuestión. 
Con los cambios, GameHelper sólo ha de usar GameObject.Find una vez, y almacena las referencias para uso futuro.

#### Historia de Usuario / Tarea :clipboard:

[Tarea DEV-037](https://trello.com/c/k48ghZEW/92-gamehelper-cache-objects-and-implement-cache-cleaner)

#### ¿Cómo probar la funcionalidad? :video_game:

Depurar Scipts/Infrastructure/GameHelper