### PR TITLE
Dev 027

### DIFF
--- a/Assets/Animation.meta
+++ b/Assets/Animation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1aa82ebf62115584584836b23636f9c8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animation/Anims.meta
+++ b/Assets/Animation/Anims.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82e96de1097dddb419181ae4e70cafc1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animation/Anims/temp-weapons_13.controller
+++ b/Assets/Animation/Anims/temp-weapons_13.controller
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-7299519288905786183
+AnimatorState:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: testAttack
+  m_Speed: 2
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: b04dfc82e60b2364594298af8110ccfe, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: temp-weapons_13
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: 5405289717228051097}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1107 &5405289717228051097
+AnimatorStateMachine:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -7299519288905786183}
+    m_Position: {x: 280, y: 120, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -7299519288905786183}

--- a/Assets/Animation/Anims/temp-weapons_13.controller.meta
+++ b/Assets/Animation/Anims/temp-weapons_13.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 21ace0e2289207a42932a7a35561b07c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animation/Anims/testAttack.anim
+++ b/Assets/Animation/Anims/testAttack.anim
@@ -1,0 +1,250 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: testAttack
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.083333336
+        value: 2
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.25
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Size.x
+    path: 
+    classID: 61
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.083333336
+        value: 2
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.25
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Size.y
+    path: 
+    classID: 61
+    script: {fileID: 0}
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: -8255595784488347372, guid: 2094d20d7aef4a042b454d70843d09db,
+        type: 3}
+    - time: 0.083333336
+      value: {fileID: -8593316180588743505, guid: 2094d20d7aef4a042b454d70843d09db,
+        type: 3}
+    - time: 0.16666667
+      value: {fileID: 4013270892021829797, guid: 2094d20d7aef4a042b454d70843d09db,
+        type: 3}
+    - time: 0.25
+      value: {fileID: -8228234910099434385, guid: 2094d20d7aef4a042b454d70843d09db,
+        type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 12
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 4197328169
+      script: {fileID: 0}
+      typeID: 61
+      customType: 0
+      isPPtrCurve: 0
+    - serializedVersion: 2
+      path: 0
+      attribute: 2368279999
+      script: {fileID: 0}
+      typeID: 61
+      customType: 0
+      isPPtrCurve: 0
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: -8255595784488347372, guid: 2094d20d7aef4a042b454d70843d09db, type: 3}
+    - {fileID: -8593316180588743505, guid: 2094d20d7aef4a042b454d70843d09db, type: 3}
+    - {fileID: 4013270892021829797, guid: 2094d20d7aef4a042b454d70843d09db, type: 3}
+    - {fileID: -8228234910099434385, guid: 2094d20d7aef4a042b454d70843d09db, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.33333334
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.083333336
+        value: 2
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.25
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Size.x
+    path: 
+    classID: 61
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.083333336
+        value: 2
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.25
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Size.y
+    path: 
+    classID: 61
+    script: {fileID: 0}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events:
+  - time: 0.33333334
+    functionName: DestroyNow
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/Animation/Anims/testAttack.anim.meta
+++ b/Assets/Animation/Anims/testAttack.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b04dfc82e60b2364594298af8110ccfe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Graphics/placeholder/temp-weapons.png
+++ b/Assets/Graphics/placeholder/temp-weapons.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37ac7d0d055b81e0167a5aac2ca4c60060d0d0a0360760e6219e88eaf026add0
+size 2310

--- a/Assets/Graphics/placeholder/temp-weapons.png.meta
+++ b/Assets/Graphics/placeholder/temp-weapons.png.meta
@@ -1,0 +1,695 @@
+fileFormatVersion: 2
+guid: 2094d20d7aef4a042b454d70843d09db
+TextureImporter:
+  internalIDToNameTable:
+  - first:
+      213: -2911609139801194109
+    second: temp-weapons_0
+  - first:
+      213: -3474905020992539056
+    second: temp-weapons_1
+  - first:
+      213: -7109226205038992642
+    second: temp-weapons_2
+  - first:
+      213: 703874431690869244
+    second: temp-weapons_3
+  - first:
+      213: 7297503736562223955
+    second: temp-weapons_4
+  - first:
+      213: 3059883664147943750
+    second: temp-weapons_5
+  - first:
+      213: 4088606397804973008
+    second: temp-weapons_6
+  - first:
+      213: -4489495748531001027
+    second: temp-weapons_7
+  - first:
+      213: -843035521335235195
+    second: temp-weapons_8
+  - first:
+      213: 2505240014706939727
+    second: temp-weapons_9
+  - first:
+      213: -6332997935826779117
+    second: temp-weapons_10
+  - first:
+      213: 511708044649086155
+    second: temp-weapons_11
+  - first:
+      213: 350637191513445606
+    second: temp-weapons_12
+  - first:
+      213: -8255595784488347372
+    second: temp-weapons_13
+  - first:
+      213: -8593316180588743505
+    second: temp-weapons_14
+  - first:
+      213: 4013270892021829797
+    second: temp-weapons_15
+  - first:
+      213: -8228234910099434385
+    second: temp-weapons_16
+  - first:
+      213: -2293677473758112810
+    second: temp-weapons_17
+  - first:
+      213: -6779679601877835167
+    second: temp-weapons_18
+  - first:
+      213: -5786898595974029525
+    second: temp-weapons_19
+  - first:
+      213: 6076930897626527424
+    second: temp-weapons_20
+  - first:
+      213: 3373897096485314000
+    second: temp-weapons_21
+  - first:
+      213: -4822416481489299606
+    second: temp-weapons_22
+  - first:
+      213: -51565131056297539
+    second: temp-weapons_23
+  - first:
+      213: 7174217977890616553
+    second: temp-weapons_24
+  - first:
+      213: -4111995752073910039
+    second: temp-weapons_25
+  - first:
+      213: 7349676152630446593
+    second: temp-weapons_26
+  - first:
+      213: -6767488642539737298
+    second: temp-weapons_27
+  - first:
+      213: -5469100550697423433
+    second: temp-weapons_28
+  - first:
+      213: -7934126810962920097
+    second: temp-weapons_29
+  - first:
+      213: 6288587805286320114
+    second: temp-weapons_30
+  - first:
+      213: -5928507649119414775
+    second: temp-weapons_31
+  - first:
+      213: 3207648788770401480
+    second: temp-weapons_32
+  - first:
+      213: 6555409384215672636
+    second: temp-weapons_33
+  - first:
+      213: -6150315861349065853
+    second: temp-weapons_34
+  - first:
+      213: 418076134532549032
+    second: temp-weapons_35
+  - first:
+      213: 8181846993535747490
+    second: temp-weapons_36
+  - first:
+      213: -5667582644053610646
+    second: temp-weapons_37
+  - first:
+      213: -7685743343760786188
+    second: temp-weapons_38
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 16
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: temp-weapons_0
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 64
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 3818e59e9e2e797d0800000000000000
+      internalID: -2911609139801194109
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_1
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 64
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 056b4835b48a6cfc0800000000000000
+      internalID: -3474905020992539056
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_2
+      rect:
+        serializedVersion: 2
+        x: 64
+        y: 64
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: ef2a0ccce64f65d90800000000000000
+      internalID: -7109226205038992642
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_3
+      rect:
+        serializedVersion: 2
+        x: 96
+        y: 64
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: cf90a6bf01aa4c900800000000000000
+      internalID: 703874431690869244
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_4
+      rect:
+        serializedVersion: 2
+        x: 128
+        y: 64
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 35b80ec0cf0f54560800000000000000
+      internalID: 7297503736562223955
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_5
+      rect:
+        serializedVersion: 2
+        x: 160
+        y: 64
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 6411f870bf3e67a20800000000000000
+      internalID: 3059883664147943750
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_6
+      rect:
+        serializedVersion: 2
+        x: 192
+        y: 64
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 0db0e8f3bd5adb830800000000000000
+      internalID: 4088606397804973008
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_7
+      rect:
+        serializedVersion: 2
+        x: 224
+        y: 64
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: d39ee20376b12b1c0800000000000000
+      internalID: -4489495748531001027
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_8
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 32
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 58de6c1f8afec44f0800000000000000
+      internalID: -843035521335235195
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_9
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 32
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: f4793b1258664c220800000000000000
+      internalID: 2505240014706939727
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_10
+      rect:
+        serializedVersion: 2
+        x: 64
+        y: 32
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 31443c75eebac18a0800000000000000
+      internalID: -6332997935826779117
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_11
+      rect:
+        serializedVersion: 2
+        x: 96
+        y: 32
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: bccb40661c3f91700800000000000000
+      internalID: 511708044649086155
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_13
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 0
+        width: 32
+        height: 32
+      alignment: 4
+      pivot: {x: 0, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 4191c50cf5b3e6d80800000000000000
+      internalID: -8255595784488347372
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_14
+      rect:
+        serializedVersion: 2
+        x: 32
+        y: 0
+        width: 32
+        height: 32
+      alignment: 4
+      pivot: {x: 0, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: fa4346d86786eb880800000000000000
+      internalID: -8593316180588743505
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_15
+      rect:
+        serializedVersion: 2
+        x: 64
+        y: 0
+        width: 32
+        height: 32
+      alignment: 4
+      pivot: {x: 0, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 5a05062fc9002b730800000000000000
+      internalID: 4013270892021829797
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_16
+      rect:
+        serializedVersion: 2
+        x: 96
+        y: 0
+        width: 32
+        height: 32
+      alignment: 4
+      pivot: {x: 0, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: f641e0fb1ff6fcd80800000000000000
+      internalID: -8228234910099434385
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_17
+      rect:
+        serializedVersion: 2
+        x: 128
+        y: 0
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 6d315537d783b20e0800000000000000
+      internalID: -2293677473758112810
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_18
+      rect:
+        serializedVersion: 2
+        x: 160
+        y: 0
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 1622c17825db9e1a0800000000000000
+      internalID: -6779679601877835167
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_19
+      rect:
+        serializedVersion: 2
+        x: 192
+        y: 0
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: b2fd2c3236ec0bfa0800000000000000
+      internalID: -5786898595974029525
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_20
+      rect:
+        serializedVersion: 2
+        x: 224
+        y: 0
+        width: 32
+        height: 32
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 0c6ff955478955450800000000000000
+      internalID: 6076930897626527424
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_12
+      rect:
+        serializedVersion: 2
+        x: 132
+        y: 48
+        width: 8
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 6e4133dfaa6bdd400800000000000000
+      internalID: 350637191513445606
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: temp-weapons_21
+      rect:
+        serializedVersion: 2
+        x: 147
+        y: 32
+        width: 8
+        height: 16
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 0dd9ab8988d72de20800000000000000
+      internalID: 3373897096485314000
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Weapons.meta
+++ b/Assets/Prefabs/Weapons.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bbf667b90a2a53f42bfb64b66a4b8217
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Weapons/Hitboxes.meta
+++ b/Assets/Prefabs/Weapons/Hitboxes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c32c251d4682a7249bfe4f97af787cfe
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Weapons/Hitboxes/KnifeHB.prefab
+++ b/Assets/Prefabs/Weapons/Hitboxes/KnifeHB.prefab
@@ -1,0 +1,160 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7334158385443366072
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7334158385443366079}
+  - component: {fileID: 7334158385443366077}
+  - component: {fileID: 7334158385443366078}
+  - component: {fileID: 7334158385443366073}
+  - component: {fileID: 7334158385443366076}
+  - component: {fileID: -4743217102218382644}
+  m_Layer: 0
+  m_Name: KnifeHB
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7334158385443366079
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7334158385443366072}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 14.3800335, y: 6.2190313, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7334158385443366077
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7334158385443366072}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e3ba40ca313566409f2942c195a5685, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TimeToDestroyInSeconds: 1
+--- !u!212 &7334158385443366078
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7334158385443366072}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -8255595784488347372, guid: 2094d20d7aef4a042b454d70843d09db,
+    type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!95 &7334158385443366073
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7334158385443366072}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 21ace0e2289207a42932a7a35561b07c, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!61 &7334158385443366076
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7334158385443366072}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2, y: 2}
+  m_EdgeRadius: 0
+--- !u!114 &-4743217102218382644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7334158385443366072}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f351fdeba34875948bc0a6821a7200bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 1
+  points: 3

--- a/Assets/Prefabs/Weapons/Hitboxes/KnifeHB.prefab.meta
+++ b/Assets/Prefabs/Weapons/Hitboxes/KnifeHB.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 32f4a321c3088724fb31af27bce24017
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Weapons/Knife.prefab
+++ b/Assets/Prefabs/Weapons/Knife.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &3972398175323087079
+--- !u!1 &1913875081881486453
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,37 +8,52 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5670929397823754911}
-  - component: {fileID: 9138850927334912666}
-  - component: {fileID: 2058518714347006174}
+  - component: {fileID: 4205975020233238246}
+  - component: {fileID: 2017736812954544512}
+  - component: {fileID: 5070138074595310629}
   m_Layer: 0
-  m_Name: Projectile
+  m_Name: Knife
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5670929397823754911
+--- !u!4 &4205975020233238246
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3972398175323087079}
+  m_GameObject: {fileID: 1913875081881486453}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.2, y: 0.2, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &9138850927334912666
+--- !u!114 &2017736812954544512
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1913875081881486453}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ba117d401c5b0d48a637f5d7058c817, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  currentCommand: 0
+  wielderTransform: {fileID: 0}
+  hitbox: {fileID: 7334158385443366072, guid: 32f4a321c3088724fb31af27bce24017, type: 3}
+--- !u!212 &5070138074595310629
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3972398175323087079}
+  m_GameObject: {fileID: 1913875081881486453}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -71,26 +86,14 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: d1134834f70f9454dbb6abfc36bbdb8d, type: 3}
-  m_Color: {r: 1, g: 0.85783035, b: 0, a: 1}
+  m_Sprite: {fileID: 350637191513445606, guid: 2094d20d7aef4a042b454d70843d09db, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 2, y: 2}
+  m_Size: {x: 0.5, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &2058518714347006174
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3972398175323087079}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: da366e92c77a4e14ea4b2fb05d3884fa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Weapons/Knife.prefab.meta
+++ b/Assets/Prefabs/Weapons/Knife.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f849aaba12447e74c98549648dc87791
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Test/Test_Jesus.unity
+++ b/Assets/Scenes/Test/Test_Jesus.unity
@@ -628,6 +628,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c7150001ae4f0bf43ba2d11fd2f71866, type: 3}
+--- !u!114 &913830620 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2017736812954544512, guid: f849aaba12447e74c98549648dc87791,
+    type: 3}
+  m_PrefabInstance: {fileID: 1914423740}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ba117d401c5b0d48a637f5d7058c817, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1368341878 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3385109607677488921, guid: 513e3d8bdf861f14cbeb14cf81632545,
@@ -640,6 +652,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18a49a7ad53a6194f832c92d8bc9dcee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &1628235724 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3565173152638740736, guid: 44caf857d2f69e046b047eb430874518,
+    type: 3}
+  m_PrefabInstance: {fileID: 1737194708}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1737194708
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -657,6 +675,11 @@ PrefabInstance:
       propertyPath: moveSpeed
       value: 10
       objectReference: {fileID: 0}
+    - target: {fileID: 2048454768646577345, guid: 44caf857d2f69e046b047eb430874518,
+        type: 3}
+      propertyPath: EquipedWeapon
+      value: 
+      objectReference: {fileID: 913830620}
     - target: {fileID: 3565173152638740736, guid: 44caf857d2f69e046b047eb430874518,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -725,6 +748,85 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 847802542}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1914423740
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1628235724}
+    m_Modifications:
+    - target: {fileID: 1913875081881486453, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_Name
+      value: Knife
+      objectReference: {fileID: 0}
+    - target: {fileID: 1913875081881486453, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2017736812954544512, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: playerTransform
+      value: 
+      objectReference: {fileID: 1628235724}
+    - target: {fileID: 4205975020233238246, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4205975020233238246, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4205975020233238246, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4205975020233238246, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4205975020233238246, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4205975020233238246, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4205975020233238246, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4205975020233238246, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4205975020233238246, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4205975020233238246, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4205975020233238246, guid: f849aaba12447e74c98549648dc87791,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f849aaba12447e74c98549648dc87791, type: 3}
 --- !u!1001 &1539080455305072708
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AutoDestroy.cs
+++ b/Assets/Scripts/AutoDestroy.cs
@@ -28,7 +28,7 @@ public class AutoDestroy : MonoBehaviour
         }
     }
     
-    bool DestroyNow(){
+    public bool DestroyNow(){
         try
         {
             GameObject.Destroy(this.gameObject);

--- a/Assets/Scripts/Controllers/PlayerController.cs
+++ b/Assets/Scripts/Controllers/PlayerController.cs
@@ -10,6 +10,9 @@ public class PlayerController : MonoBehaviour
     private SpriteRenderer sr;
     private Health hc;
 
+    //Weapon
+    private WeaponController wc;
+
     //Movement Settings
     [SerializeField]
     private float moveSpeed;
@@ -20,11 +23,8 @@ public class PlayerController : MonoBehaviour
     [SerializeField]
     private Sprite sprite;
 
-    //Attack Settings
-    //temporal
-    [SerializeField]
-    private GameObject attackMask;
-    private GameObject atk;
+    //Weapon Settings
+    public WeaponController EquipedWeapon;
 
     [SerializeField] 
     private GameObject testProjectile;
@@ -33,6 +33,13 @@ public class PlayerController : MonoBehaviour
     public struct PlayerStatus{
         public bool dead;
         public bool canMove;
+        public bool canShoot;
+
+        public void init(){
+            dead = false;
+            canMove = true;
+            canShoot = false;
+        }
 
         public void set_dead(){
             dead = true;
@@ -47,8 +54,7 @@ public class PlayerController : MonoBehaviour
     {
 
         //PlayerStatus setup
-        status.dead = false;
-        status.canMove = true;
+        status.init();
 
         //Create and save component references
         sr = gameObject.AddComponent<SpriteRenderer>();
@@ -82,7 +88,6 @@ public class PlayerController : MonoBehaviour
             bc.isTrigger = true;
         }
 
-
         //Movement
         if(status.canMove)
             rb.velocity = new Vector2( InputController.HorizontalMovement() * moveSpeed ,rb.velocity.y);
@@ -92,17 +97,25 @@ public class PlayerController : MonoBehaviour
             rb.AddForce( new Vector2(0, jumpForce) );
         }
 
-        if(InputController.MeleeAttack(ICActions.keyDown) && attackMask != null && atk == null){
-            atk = Instantiate(attackMask);
-            atk.AddComponent<Damage>();
-            atk.GetComponent<Damage>().setDamage(DamageTypes.PLY_MELEE, 10);
-            atk.transform.parent = this.transform;
-            //set postiion (temporal)
-            var mePos = this.transform.position;
-            atk.transform.position = new Vector2(mePos.x + 1, mePos.y);
+        //Handle weapons
+        if(EquipedWeapon!=null){
+            var weapon = EquipedWeapon;
+            weapon.wielderTransform = this.transform;
+            if(InputController.mouseAction(ICActions.key, 1)){
+                weapon.Set(WeaponCommands.hold);
+                if(InputController.mouseAction(ICActions.keyDown, 0)){
+                    weapon.Attack(DamageTypes.PLY_MELEE);
+                }
+            } else if (InputController.mouseAction(ICActions.key, 2)){
+                weapon.Set(WeaponCommands.point);
+            } else if(Input.GetKey(KeyCode.Alpha2)) {
+                weapon.Set(WeaponCommands.store);
+            } else {
+                weapon.Set(WeaponCommands.sheath);
+            }
         }
 
-        if(InputController.Shot(ICActions.keyDown) && testProjectile != null){
+        if(InputController.Shot(ICActions.keyDown) && testProjectile != null && status.canShoot){
             var proj = Instantiate(testProjectile);
             proj.AddComponent<Damage>();
             proj.GetComponent<Damage>().setDamage(DamageTypes.PLY_BULLET, 20);

--- a/Assets/Scripts/Controllers/WeaponController.cs
+++ b/Assets/Scripts/Controllers/WeaponController.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class WeaponController : MonoBehaviour
+{
+
+    [Header("Config")]
+    public int damage;
+    public GameObject hitbox;
+
+    [Header("Info")]
+    public WeaponCommands currentCommand;
+    public Transform wielderTransform;
+
+    private GameObject currentAttack;
+
+    public void Set(WeaponCommands command){
+
+        if(!WeaponCommands.aim.HasFlag(command) && currentCommand == command) return;
+
+        switch(command){
+            case WeaponCommands.hold:
+                AimWeapon(wielderTransform.position);
+                break;
+
+            case WeaponCommands.point:
+                PointWeapon(wielderTransform.position);
+                break;
+
+            case WeaponCommands.sheath:
+                SheathWeapon();
+                break;
+
+            case WeaponCommands.store:
+                StoreWeapon();
+                break;
+
+        }
+    }
+
+    public GameObject Attack(DamageTypes damageType){
+        //TODO: handle ranged weapons
+        if(currentAttack != null) return currentAttack;
+        var origin = wielderTransform.transform.position;
+        var atk = Instantiate(hitbox);
+        atk.AddComponent<Damage>().setDamage(DamageTypes.PLY_MELEE, damage);
+        atk.transform.position = this.transform.position;  
+        atk.transform.rotation = Quaternion.LookRotation(Vector3.forward, CursorDirection(origin));
+        atk.transform.rotation *= Quaternion.Euler(0,0,90);
+        return currentAttack = atk;
+    }
+
+    #region status
+    private void AimWeapon(Vector2 origin){
+        this.transform.rotation = Quaternion.Euler(0,0,0);
+        this.transform.localPosition = CursorDirection(origin);
+        currentCommand = WeaponCommands.hold;
+    }
+
+    private void PointWeapon(Vector2 origin){
+        this.transform.rotation = Quaternion.LookRotation(Vector3.forward, CursorDirection(origin));
+        this.transform.localPosition = CursorDirection(origin);
+        currentCommand = WeaponCommands.point;
+    }
+
+    private void SheathWeapon()
+    {
+        this.transform.rotation = Quaternion.Euler(0,0,-120);
+        this.transform.localPosition = new Vector3(0,-0.25f,-1);
+        currentCommand = WeaponCommands.sheath;
+    }
+
+    private void StoreWeapon()
+    {
+        this.transform.rotation = Quaternion.Euler(0,0,190);
+        this.transform.localPosition = new Vector3(-0.3f,0,1);
+        currentCommand = WeaponCommands.store;
+    }
+
+    private void DropWeapon(){
+        throw new System.NotImplementedException();
+    }
+
+    private void ThrowWeapon(){
+        throw new System.NotImplementedException();
+    }
+
+    //TODO: replace with inputcontroller method
+    private Vector3 CursorDirection(Vector2 origin){
+        var dir = Camera.main.ScreenToWorldPoint(InputController.MousePosition()) - (Vector3)origin;
+        var distance = 1.5f;
+        dir += new Vector3(0,0,-1);
+        return dir.normalized * distance;
+    }
+#endregion
+
+}

--- a/Assets/Scripts/Controllers/WeaponController.cs.meta
+++ b/Assets/Scripts/Controllers/WeaponController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ba117d401c5b0d48a637f5d7058c817
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Infrastructure/Enums/WeaponEnums.cs
+++ b/Assets/Scripts/Infrastructure/Enums/WeaponEnums.cs
@@ -1,0 +1,9 @@
+﻿public enum WeaponCommands{
+    hold = 1 << 1,
+    point = 1 << 2,
+    sheath = 1 << 3,
+    store = 1 << 4,
+    none = 1 << 5,
+
+    aim = hold | point
+}

--- a/Assets/Scripts/Infrastructure/Enums/WeaponEnums.cs.meta
+++ b/Assets/Scripts/Infrastructure/Enums/WeaponEnums.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79bfc3ebba2c9fc4f84e641cca262aaf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Descripción de la Funcionalidad :black_nib:

Se añadió el controlador de armas e infraestructura necesaria (weaponEnums).

El controlador recibe un comando y lo ejecuta. 

#### Historia de Usuario / Tarea :clipboard:

[DEV-027](https://trello.com/c/vRenJm0I/82-player-ataque-melee-direccional)

#### ¿Cómo probar la funcionalidad? :video_game:

En Test-Jesus, colocar prefab Knife en equipedWeapon del jugador. 
Al mantener presionado 2, el jugador guarda el arma en su espalda.
Al mantener presionado MB2, el jugador apunta el arma en la dirección del cursor.
Al mantener presionado MB1. el jugador sostiene el arma en la dirección del cursor.
Al no presionar nada, el jugador guarda el arma en la cintura.

Al mantener presionado MB1 y presionar MB0. el arma crea un hitbox con un componente de daño.