### PR TITLE
Dev 036

### DIFF
--- a/Assets/Scenes/Test/Test_Jesus.unity
+++ b/Assets/Scenes/Test/Test_Jesus.unity
@@ -220,6 +220,78 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &140985735
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 140985738}
+  - component: {fileID: 140985737}
+  - component: {fileID: 140985736}
+  m_Layer: 0
+  m_Name: MELEE
+  m_TagString: Untagged
+  m_Icon: {fileID: -1412012063857583412, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &140985736
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 140985735}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f351fdeba34875948bc0a6821a7200bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 16
+  points: 500
+--- !u!61 &140985737
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 140985735}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!4 &140985738
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 140985735}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.06, y: 8.76, z: -4.834961}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &266974110
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -628,6 +700,78 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c7150001ae4f0bf43ba2d11fd2f71866, type: 3}
+--- !u!1 &911678597
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 911678600}
+  - component: {fileID: 911678599}
+  - component: {fileID: 911678598}
+  m_Layer: 0
+  m_Name: BULLET
+  m_TagString: Untagged
+  m_Icon: {fileID: 5132851093641282708, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &911678598
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 911678597}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f351fdeba34875948bc0a6821a7200bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 8
+  points: 10
+--- !u!61 &911678599
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 911678597}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!4 &911678600
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 911678597}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.05, y: 6.65, z: -4.834961}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1368341878 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3385109607677488921, guid: 513e3d8bdf861f14cbeb14cf81632545,
@@ -656,6 +800,11 @@ PrefabInstance:
         type: 3}
       propertyPath: moveSpeed
       value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2048454768646577345, guid: 44caf857d2f69e046b047eb430874518,
+        type: 3}
+      propertyPath: damageFrom
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 3565173152638740736, guid: 44caf857d2f69e046b047eb430874518,
         type: 3}

--- a/Assets/Scripts/AI/EnemyController.cs
+++ b/Assets/Scripts/AI/EnemyController.cs
@@ -25,6 +25,7 @@ public class EnemyController : MonoBehaviour
     public float closeDistance;
     public float moveSpeed;
     public Sprite sprite;
+    public DamageTypes damageFrom;
     
     // Start is called before the first frame update
     void Start()
@@ -45,6 +46,7 @@ public class EnemyController : MonoBehaviour
         //TEST: These attributes will be set differently
         closeDistance = 3f;
         moveSpeed = 5f;
+        damageFrom = DamageTypes.PLAYER_DAMAGE;
         //
         
     }
@@ -55,12 +57,9 @@ public class EnemyController : MonoBehaviour
         //Check if it is necessary a transition to a new Behaviour
         if(nextBehaviour != null) doBehaviourTransition();
         else
-        {
-            //Check if entity is dead
-            if(!hc.IsAlive && currentBehaviour.getBehaviourName() != "Dead") nextBehaviour = new Dead(this);
-            
+        {           
             //Calculate next behaviour (when is Idle)
-            else if(currentBehaviour.getBehaviourName() == "Idle") calculateNextBehaviour();
+            if(currentBehaviour.getBehaviourName() == "Idle") calculateNextBehaviour();
 
             else currentBehaviour.update();
         }
@@ -80,5 +79,17 @@ public class EnemyController : MonoBehaviour
         currentBehaviour = nextBehaviour;
         nextBehaviour = null;
         currentBehaviour.init();
+    }
+
+    //Damage detection
+    void OnTriggerEnter2D(Collider2D other) {
+        if(other.TryGetComponent<Damage>(out var dmg)){
+            if(damageFrom.HasFlag(dmg.type)){
+                hc.decrementHealthPoints( dmg.damagePoints );
+                if(!hc.IsAlive && currentBehaviour.getBehaviourName() != "Dead"){
+                    nextBehaviour = new Dead(this);
+                }
+            }
+        }
     }
 }

--- a/Assets/Scripts/Controllers/PlayerController.cs
+++ b/Assets/Scripts/Controllers/PlayerController.cs
@@ -26,6 +26,8 @@ public class PlayerController : MonoBehaviour
     private GameObject attackMask;
     private GameObject atk;
 
+    private DamageTypes damageFrom = DamageTypes.ENM_DAMAGE;
+
     [SerializeField] 
     private GameObject testProjectile;
 
@@ -42,6 +44,16 @@ public class PlayerController : MonoBehaviour
     }
     PlayerStatus status = new PlayerStatus();
     
+    private void OnTriggerEnter2D(Collider2D other) {
+        if(other.TryGetComponent<Damage>(out var dmg)){
+            if(damageFrom.HasFlag(dmg.type)){
+                hc.decrementHealthPoints( dmg.damagePoints );
+                if(!hc.IsAlive && !status.dead){
+                    PlayerDeath();
+                }
+            }
+        }
+    }
 
     void Start()
     {
@@ -72,17 +84,15 @@ public class PlayerController : MonoBehaviour
         }
     }
 
+    void PlayerDeath(){
+        status.set_dead();
+        this.gameObject.GetComponent<Rigidbody2D>().freezeRotation = false;
+        CorpseController corpse = gameObject.AddComponent<CorpseController>();
+        bc.isTrigger = true;
+    }
+
     void Update()
     {
-
-        if(!status.dead && !hc.IsAlive){
-            status.set_dead();
-            this.gameObject.GetComponent<Rigidbody2D>().freezeRotation = false;
-            CorpseController corpse = gameObject.AddComponent<CorpseController>();
-            bc.isTrigger = true;
-        }
-
-
         //Movement
         if(status.canMove)
             rb.velocity = new Vector2( InputController.HorizontalMovement() * moveSpeed ,rb.velocity.y);

--- a/Assets/Scripts/Editor/HealthEditor.cs
+++ b/Assets/Scripts/Editor/HealthEditor.cs
@@ -7,14 +7,12 @@ public class HealthEditor : Editor
 {
     public override void OnInspectorGUI()
     {
+
+        DrawDefaultInspector();
         //Referencia al componente Health para poder acceder a sus propiedades y métodos.
         Health health = (Health)target;
 
         //Campos de propiedades del componente Health.
-        EditorGUILayout.Space();
-        health.HealthPoints = EditorGUILayout.IntField("Health points", health.HealthPoints);
-        health.MaxHealthPoints = EditorGUILayout.IntField("Max health points", health.MaxHealthPoints);
-        health.MinHealthPoints = EditorGUILayout.IntField("Min health points", health.MinHealthPoints);
         health.IsAlive = EditorGUILayout.Toggle("Is alive", health.IsAlive);
         EditorGUILayout.Space(20);
         

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -3,8 +3,11 @@
 [ExecuteInEditMode]
 public class Health : MonoBehaviour
 {
+    [SerializeField]
     private int healthPoints;
+    [SerializeField]
     private int maxHealthPoints;
+    [SerializeField]
     private int minHealthPoints;
     private bool alive;
 

--- a/Assets/Scripts/Infrastructure/Enums/DamageType.cs
+++ b/Assets/Scripts/Infrastructure/Enums/DamageType.cs
@@ -1,15 +1,16 @@
-﻿public enum DamageTypes
+﻿[System.Flags]
+public enum DamageTypes
 {
   //Player damage types  
-  PLY_BULLET,
-  PLY_MELEE,
+  PLY_BULLET = 1 << 1,
+  PLY_MELEE = 1 << 2,
 
   //Enemy damage types
-  ENM_BULLET,
-  ENM_MELEE,
+  ENM_BULLET = 1 << 3,
+  ENM_MELEE = 1 << 4 ,
   
   //Global damage types
   PLAYER_DAMAGE = PLY_BULLET | PLY_MELEE,
   ENM_DAMAGE = ENM_BULLET | ENM_MELEE,
-  GLOBAL_DAMAGE = PLY_BULLET | PLY_MELEE | ENM_BULLET | ENM_MELEE
+  GLOBAL_DAMAGE = ENM_DAMAGE | PLAYER_DAMAGE
 }


### PR DESCRIPTION
## Descripción de la Funcionalidad :black_nib:

Se añade OnTriggerEnter al EnemyController para detectar colisiones con objetos que tengan un tipo de daño que reste vida al enemigo.
Se realizó usando la misma lógica implementada en el player.
La muerte ya no se comprueba en cada frame. Solo se comprueba en el TriggerEnter (por ahora único método que puede restar vida al enemigo)

  


#### Historia de Usuario / Tarea :clipboard:

  

[Detectar daño del player](https://trello.com/c/A87BNnKe/91-detectar-da%C3%B1o-del-player)

  

#### He realizado las siguientes tareas que requieren revisión :books: :mag_right:

N/A

#### ¿Cómo probar la funcionalidad? :video_game:

En cualquier escena con los prefab Player y Enemy, si usamos el ataque Melee del Player sobre el Enemy, este último perderá vida.

**Nota:** Cambios hechos a partir de la rama dev-031 ([Player: Recibir daño enemigo](https://trello.com/c/HfobfeZW/85-player-recibir-da%C3%B1o-enemigo))